### PR TITLE
修改关于home directory的翻译

### DIFF
--- a/_2020/course-shell.md
+++ b/_2020/course-shell.md
@@ -260,7 +260,7 @@ $ echo 1 | sudo tee /sys/class/leds/input6::scrolllock/brightness
 
 3. 使用 `chmod` 命令改变权限，使 `./semester` 能够成功执行，不要使用 `sh semester` 来执行该程序。您的 shell 是如何知晓这个文件需要使用 `sh` 来解析呢？更多信息请参考：[shebang](https://en.wikipedia.org/wiki/Shebang_(Unix))
 
-4. 使用 `|` 和 `>` ，将 `semester` 文件输出的最后更改日期信息，写入/home目录下的 `last-modified.txt` 的文件中
+4. 使用 `|` 和 `>` ，将 `semester` 文件输出的最后更改日期信息，写入主目录下的 `last-modified.txt` 的文件中
 
 5. 写一段命令来从 `/sys` 中获取笔记本的电量信息，或者台式机 CPU 的温度。注意：macOS 并没有 sysfs，所以 Mac 用户可以跳过这一题。
 


### PR DESCRIPTION
我认为home directory不该翻译为/home目录，翻译为主目录应该更为合理。
例如在macOS下，home directory应该指的是/Users/xxx，而不是/home。
