### PR TITLE
Update shell-tools-solution.md

### DIFF
--- a/_2020/solutions/shell-tools-solution.md
+++ b/_2020/solutions/shell-tools-solution.md
@@ -51,7 +51,7 @@ solution: true
         exit 1
     fi
 
-    echo "Everything went according to plan”
+    echo "Everything went according to plan"
     ```
 
     使用 while 循环完成
@@ -60,7 +60,7 @@ solution: true
 
     while true
     do
-        ./buggy.sh 2&> out.log
+        ./buggy.sh 2> out.log
         if [[ $? -ne 0 ]]; then
             echo "failed after $count times"
             cat out.log
@@ -75,7 +75,7 @@ solution: true
     ```bash
     for ((count=1;;count++))
     do
-        ./buggy.sh 2&> out.log
+        ./buggy.sh 2> out.log
         if [[ $? -ne 0 ]]; then
             echo "failed after $count times"
             cat out.log
@@ -93,7 +93,7 @@ solution: true
     until [[ "$?" -ne 0 ]];
     do
         count=$((count+1))
-        ./random.sh &> out.txt
+        ./random.sh 2> out.txt
     done
 
     echo "found error after $count runs"


### PR DESCRIPTION
1.将“的符号错误修改过来

2.`&>`把标准输出和错误一起重定向到一个文件中符合题意，但最后输出的结果并不包含"Everything went according to plan"
`2&>`意思我不明白，确实会输出"Everything went according to plan"，问题是"The error was using magic numbers"会输出两次
`2>`使用标准错误输出，得到的结果与`2&>`类似，区别"The error was using magic numbers"只输出一次