### PR TITLE
typo `kill -t` => `kill -l`

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -122,7 +122,7 @@ $ jobs
 
 `SIGKILL` 是一个特殊的信号，它不能被进程捕获并且它会马上结束该进程。不过这样做会有一些副作用，例如留下孤儿进程。
 
-您可以在 [这里](https://en.wikipedia.org/wiki/Signal_(IPC)) 或输入 [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) 或使用 `kill -t` 来获取更多关于信号的信息。
+您可以在 [这里](https://en.wikipedia.org/wiki/Signal_(IPC)) 或输入 [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) 或使用 `kill -l` 来获取更多关于信号的信息。
 
 
 # 终端多路复用


### PR DESCRIPTION
see original [here](https://github.com/missing-semester/missing-semester/blob/master/_2020/command-line.md)