### PR TITLE
SSH 客户端 -i 参数接受的应该是私钥文件路径

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -322,7 +322,7 @@ ssh-keygen -o -a 100 -t ed25519 -f ~/.ssh/id_ed25519
 `ssh` 会查询 `.ssh/authorized_keys` 来确认那些用户可以被允许登录。您可以通过下面的命令将一个公钥拷贝到这里：
 
 ```bash
-cat .ssh/id_ed25519.pub | ssh foobar@remote 'cat >> ~/.ssh/authorized_keys'
+cat .ssh/id_ed25519 | ssh foobar@remote 'cat >> ~/.ssh/authorized_keys'
 ```
 
 如果支持 `ssh-copy-id` 的话，可以使用下面这种更简单的解决方案：


### PR DESCRIPTION
可以去看看 ssh 的 manpage 或者试跑一下，这边 macOS 上遇到的报错是 Permissions 0644 for '/Users/username/.ssh/id_ed25519.pub' are too open ，这个英文版也是需要更新的。