### PR TITLE
修改命令行环境翻译问题

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -62,7 +62,7 @@ I got a SIGINT, but I am not stopping
 
 ## 暂停和后台执行进程
 
-信号可以让进程做其他的事情，而不仅仅是终止它们。例如，`SIGSTOP` 会让进程暂停。在终端中，键入 `Ctrl-Z` 会让 shell 发送 `SIGTSTP` 信号。
+信号可以让进程做其他的事情，而不仅仅是终止它们。例如，`SIGSTOP` 会让进程暂停。在终端中，键入 `Ctrl-Z` 会让 shell 发送 `SIGTSTP` 信号，`SIGTSTP`是 Terminal Stop 的缩写（即`terminal`版本的SIGSTOP）。
 
 我们可以使用 [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) 或 [`bg`](http://man7.org/linux/man-pages/man1/bg.1p.html) 命令恢复暂停的工作。它们分别表示在前台继续或在后台继续。
 


### PR DESCRIPTION
英语原文中是有写SIGTSTP是什么意思，去掉了英语原文中这句导致上下文看起来特别奇怪，前面在说SIGSTOP，而后面又说SIGTSTP，读者很难搞清楚两者到底是什么关系，甚至会认为后面是不是写错了，所以后面这句对SIGTSTP和STGSTOP的关系的解释应该要加上