### PR TITLE
补充git restore命令

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -394,6 +394,7 @@ command is used for merging.
 - `git commit --amend`: 编辑提交的内容或信息
 - `git reset HEAD <file>`: 恢复暂存的文件
 - `git checkout -- <file>`: 丢弃修改
+- `git restore`: git2.32版本后取代git reset 进行许多撤销操作
 
 # Git 高级操作
 


### PR DESCRIPTION
对于撤销命令git reset来说，从git2.23版本开始可以用git restore代替git reset命令进行许多撤销操作：连接如下
https://git-scm.com/book/en/v2/Git-Basics-Undoing-Things#:~:text=we%20just%20covered.-,From%20Git%20version%202.23.0%20onwards%2C%20Git%20will%20use%20git%20restore,and%20undo%20things%20with%20git%20restore%20instead%20of%20git%20reset.,-Unstaging%20a%20Staged