### PR TITLE
docs: fix 3 typos in comments and documentation

### DIFF
--- a/_2019/automation.md
+++ b/_2019/automation.md
@@ -52,7 +52,7 @@ To deal with the environment, make sure that you use absolute paths in all your 
 * * * * *   user  /path/to/cronscripts/every_minute.sh >> /tmp/cron_every_minute.log 2>&1
 ```
 
-And write the script in a separate file. Remember that `>>` appends to the file and that `2>&1` redirects `stderr` to `stdout` (you might to want keep them separate though).
+And write the script in a separate file. Remember that `>>` appends to the file and that `2>&1` redirects `stderr` to `stdout` (you might want to keep them separate though).
 
 ## Anacron
 

--- a/_2019/dotfiles.md
+++ b/_2019/dotfiles.md
@@ -12,7 +12,7 @@ Many programs are configured using plain-text files known as "dotfiles"
 hidden in the directory listing `ls` by default).
 
 A lot of the tools you use probably have a lot of settings that can be tuned
-pretty finely. Often times, tools are customized with specialized languages,
+pretty finely. Oftentimes, tools are customized with specialized languages,
 e.g. Vimscript for Vim or the shell's own language for a shell.
 
 Customizing and adapting your tools to your preferred workflow will make you

--- a/_2019/virtual-machines.md
+++ b/_2019/virtual-machines.md
@@ -122,7 +122,7 @@ there's also a way to specify any external ports that should be
 available, and an _entrypoint_ that dictates what command should be run
 when the container is started (like a grading script).
 
-In a similar fashion to code repository websites (like [GitHub](https://github.com/)) there are some container repository websites (like [DockerHub](https://hub.docker.com/))where many software services have prebuilt images that one can easily deploy.
+In a similar fashion to code repository websites (like [GitHub](https://github.com/)) there are some container repository websites (like [DockerHub](https://hub.docker.com/)) where many software services have prebuilt images that one can easily deploy.
 
 ## Exercises
 


### PR DESCRIPTION
## Summary

Fix 3 issues across 3 files:

- `_2019/dotfiles.md`: "Often times" → "Oftentimes" (incorrect two-word form; standard English is one word)
- `_2019/automation.md`: "you might to want keep" → "you might want to keep" (word order error)
- `_2019/virtual-machines.md`: "))where" → ")) where" (missing space after closing parenthesis)

No functional changes — comments/documentation only.

## Test plan

- [ ] Verify rendered markdown displays correctly on the site
- [ ] Confirm no unintended changes to surrounding content